### PR TITLE
Add native R port of guenther2023ViSpa (documented version)

### DIFF
--- a/scripts/examples_R/guenther2023ViSpa/generate_prompts.R
+++ b/scripts/examples_R/guenther2023ViSpa/generate_prompts.R
@@ -1,26 +1,46 @@
+# =============================================================================
+# generate_prompts.R
+# -----------------------------------------------------------------------------
+# Native-R port of guenther2023ViSpa/generate_prompts.py.
+#
+# Reads the tidy per-trial CSV written by preprocess_data.R and produces one
+# narrative prompt per participant, serialized as JSONL (one JSON object per
+# line) for downstream LLM evaluation.
+#
+# Pipeline:
+#   processed_data/exp1.csv
+#     |
+#     v
+#   prompts.jsonl
+#     each line: {"text": <prompt>, "experiment": "guenther2023ViSpa",
+#                 "participant_id": <int>}
+#
+# Each participant's prompt consists of:
+#   1. The task instructions shown to the human participant
+#   2. A chronological replay of the participant's trials, one line per trial,
+#      phrased as "Which look the most similar? ... You choose <<X>> ..."
+#
+# Usage:
+#   Rscript generate_prompts.R
+#
+# Requires: readr, jsonlite  (install.packages(c("readr", "jsonlite")))
+# =============================================================================
+
 suppressPackageStartupMessages({
   library(readr)
   library(jsonlite)
 })
 
-args <- commandArgs(trailingOnly = FALSE)
-script_arg <- sub("^--file=", "", args[grep("^--file=", args)])
-base_dir <- if (length(script_arg) > 0) {
-  normalizePath(dirname(script_arg))
-} else {
-  normalizePath(".")
-}
+# -----------------------------------------------------------------------------
+# Configuration
+# -----------------------------------------------------------------------------
 
-df <- read_csv(file.path(base_dir, "processed_data", "exp1.csv"), show_col_types = FALSE, progress = FALSE)
+EXPERIMENT_NAME <- "guenther2023ViSpa"
 
-df <- df[order(df$participant_id, df$trial_id), , drop = FALSE]
-
-df$participant_id <- match(df$participant_id, unique(df$participant_id))
-
-participants <- unique(df$participant_id)
-trials <- 0:max(df$trial_id)
-
-instruction_lines <- c(
+# The instruction block shown to participants. Lines are joined with a blank
+# line between them ("\n\n"), matching the rendered form of the Python
+# triple-quoted string literal in the source pipeline.
+INSTRUCTION_LINES <- c(
   "Instructions",
   "In the following study, you will be presented with sets of four word pairs.",
   "Your task is to judge which of the objects described by these four pairs look the most similar and which the least similar. Of course, you will have to pick two different pairs for these two questions.",
@@ -32,35 +52,94 @@ instruction_lines <- c(
   "By pressing the ESC key, you will end the fullscreen mode. This does not hinder you from continuing the experiment, but you cannot switch back to fullscreen mode. If possible, we want to ask you to stay in fullscreen mode for the whole duration of the experiment.",
   "The study will start with two practice trials in which you receive feedback."
 )
-instruction <- paste0(paste(instruction_lines, collapse = "\n\n"), "\n")
+INSTRUCTION <- paste0(paste(INSTRUCTION_LINES, collapse = "\n\n"), "\n")
 
-out_path <- file.path(base_dir, "prompts.jsonl")
-con <- file(out_path, open = "wb")
-on.exit(close(con), add = TRUE)
+# Trial sentence template. `%s` placeholders are filled with, in order:
+#   stimulus, best, stimulus, worst.
+TRIAL_TEMPLATE <- paste0(
+  "Which look the most similar? %s. You choose <<%s>> as most similar. ",
+  "Which look the least similar? %s. You choose <<%s>> as least similar \n "
+)
 
-for (participant in participants) {
-  df_p <- df[df$participant_id == participant, , drop = FALSE]
-  prompt <- instruction
-  for (trial in trials) {
-    row <- df_p[df_p$trial_id == trial, , drop = FALSE]
-    if (nrow(row) > 0) {
-      stimulus <- row$stimulus[1]
-      best <- row$best[1]
-      worst <- row$worst[1]
-      datapoint <- sprintf(
-        "Which look the most similar? %s. You choose <<%s>> as most similar. Which look the least similar? %s. You choose <<%s>> as least similar \n ",
-        stimulus, best, stimulus, worst
-      )
-      prompt <- paste0(prompt, datapoint)
-    }
-  }
-  prompt <- paste0(prompt, "\n")
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
 
-  line <- paste0(
-    '{"text": ', toJSON(prompt, auto_unbox = TRUE),
-    ', "experiment": ', toJSON("guenther2023ViSpa", auto_unbox = TRUE),
-    ', "participant_id": ', as.integer(participant),
+# Resolve base_dir to the directory containing this script (so relative paths
+# work no matter which cwd the user runs Rscript from).
+script_base_dir <- function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  script_arg <- sub("^--file=", "", args[grep("^--file=", args)])
+  if (length(script_arg) > 0) normalizePath(dirname(script_arg)) else normalizePath(".")
+}
+
+# Serialize a single participant's record as one JSONL line.
+#
+# We build the JSON manually (rather than calling toJSON on the whole list) so
+# that the separators match Python's default `json.dumps` output used by the
+# `jsonlines` library: ", " between fields and ": " after each key. jsonlite's
+# built-in compact mode omits those spaces, which would produce a byte-level
+# mismatch with the reference Python pipeline.
+#
+# We still delegate the *string escaping* of `text` and `experiment` to
+# jsonlite::toJSON so that embedded quotes, backslashes, and newlines are
+# encoded correctly.
+format_jsonl_line <- function(text, experiment, participant_id) {
+  paste0(
+    '{"text": ',           toJSON(text,       auto_unbox = TRUE),
+    ', "experiment": ',    toJSON(experiment, auto_unbox = TRUE),
+    ', "participant_id": ', as.integer(participant_id),
     '}'
   )
-  writeLines(line, con, sep = "\n")
+}
+
+# Build the full prompt for one participant: instruction + replay of trials.
+build_participant_prompt <- function(df_participant, trial_indices) {
+  prompt <- INSTRUCTION
+  for (trial in trial_indices) {
+    row <- df_participant[df_participant$trial_id == trial, , drop = FALSE]
+    if (nrow(row) > 0) {
+      prompt <- paste0(
+        prompt,
+        sprintf(TRIAL_TEMPLATE, row$stimulus[1], row$best[1], row$stimulus[1], row$worst[1])
+      )
+    }
+  }
+  paste0(prompt, "\n")
+}
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+
+main <- function() {
+  base_dir <- script_base_dir()
+  df <- read_csv(
+    file.path(base_dir, "processed_data", "exp1.csv"),
+    show_col_types = FALSE, progress = FALSE
+  )
+
+  # Stable participant/trial ordering, then remap raw (anonymized) participant
+  # IDs to 1..N in first-appearance order. `match(x, unique(x))` is the idiom
+  # equivalent to pandas' `map({p: i+1 for i, p in enumerate(unique)})`.
+  df <- df[order(df$participant_id, df$trial_id), , drop = FALSE]
+  df$participant_id <- match(df$participant_id, unique(df$participant_id))
+
+  participants   <- unique(df$participant_id)
+  trial_indices  <- 0:max(df$trial_id)  # mirrors Python range(max + 1)
+
+  out_path <- file.path(base_dir, "prompts.jsonl")
+  con <- file(out_path, open = "wb")
+  on.exit(close(con), add = TRUE)
+
+  for (p in participants) {
+    df_p   <- df[df$participant_id == p, , drop = FALSE]
+    prompt <- build_participant_prompt(df_p, trial_indices)
+    line   <- format_jsonl_line(prompt, EXPERIMENT_NAME, p)
+    writeLines(line, con, sep = "\n")
+  }
+}
+
+if (sys.nframe() == 0) {
+  main()
 }

--- a/scripts/examples_R/guenther2023ViSpa/preprocess_data.R
+++ b/scripts/examples_R/guenther2023ViSpa/preprocess_data.R
@@ -1,13 +1,43 @@
+# =============================================================================
+# preprocess_data.R
+# -----------------------------------------------------------------------------
+# Native-R port of guenther2023ViSpa/preprocess_data.py.
+#
+# Reads the raw TSV collected for the ViSpa visual-similarity judgement task
+# and emits a tidy, per-trial CSV that downstream prompt generation consumes.
+#
+# Pipeline:
+#   original_data/data_study1_ratings_words_complete.txt   (raw TSV, 33,055 rows)
+#     |
+#     v
+#   processed_data/exp1.csv
+#     columns: participant_id, trial_id, stimulus, best, worst
+#
+# Side effect: writes CODEBOOK.csv if it does not already exist.
+#
+# Usage:
+#   Rscript preprocess_data.R
+#
+# Requires: readr  (install.packages("readr"))
+# =============================================================================
+
 suppressPackageStartupMessages({
   library(readr)
 })
 
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+# Create processed_data/ if it does not yet exist. Returns the directory path.
 ensure_processed_dir <- function(base_dir) {
   processed_dir <- file.path(base_dir, "processed_data")
   dir.create(processed_dir, showWarnings = FALSE, recursive = TRUE)
   processed_dir
 }
 
+# Idempotently write a CODEBOOK.csv describing the output columns. If the file
+# already exists we leave it untouched so hand-curated edits are preserved.
 write_codebook <- function(base_dir) {
   codebook_path <- file.path(base_dir, "CODEBOOK.csv")
   if (file.exists(codebook_path)) {
@@ -27,35 +57,66 @@ write_codebook <- function(base_dir) {
   write.csv(codebook, codebook_path, row.names = FALSE)
 }
 
+# -----------------------------------------------------------------------------
+# Core preprocessing
+# -----------------------------------------------------------------------------
+
 preprocess <- function(base_dir) {
-  original_path <- file.path(base_dir, "original_data", "data_study1_ratings_words_complete.txt")
+  original_path <- file.path(
+    base_dir, "original_data", "data_study1_ratings_words_complete.txt"
+  )
   processed_dir <- ensure_processed_dir(base_dir)
   write_codebook(base_dir)
 
+  # The raw file is TSV with a JSON-encoded `responses` column that contains
+  # embedded quotes. readr::read_tsv handles RFC-style quoting correctly; base
+  # R's read.delim tends to mis-parse these rows.
   df <- read_tsv(original_path, show_col_types = FALSE, progress = FALSE)
 
-  for (col in c("option1", "option2", "option3", "option4")) {
+  # Ensure all four option columns exist, even if the raw file is missing one.
+  # The original Python pipeline makes the same defensive check.
+  option_cols <- c("option1", "option2", "option3", "option4")
+  for (col in option_cols) {
     if (!col %in% names(df)) df[[col]] <- ""
   }
+
+  # Concatenate the four options into a single stimulus string,
+  # e.g. "apple - peach; dog - wolf; lamp - soldier; car - street".
   df$stimulus <- paste(
-    trimws(as.character(df$option1)), trimws(as.character(df$option2)),
-    trimws(as.character(df$option3)), trimws(as.character(df$option4)),
+    trimws(as.character(df$option1)),
+    trimws(as.character(df$option2)),
+    trimws(as.character(df$option3)),
+    trimws(as.character(df$option4)),
     sep = "; "
   )
 
+  # Replace the raw trial identifier with a 1..N trial-order index.
+  #
+  # Gotcha: we must pass `levels = unique(...)` so that factor levels are
+  # assigned in first-appearance order. This mirrors pandas' `factorize()`.
+  # Without this, R's default `factor()` would sort levels alphabetically and
+  # produce different integer labels than the Python pipeline.
   if ("trial_id" %in% names(df)) {
     df$trial_id <- as.integer(factor(df$trial_id, levels = unique(df$trial_id)))
   }
 
-  cols <- c("participant_id", "trial_id", "stimulus", "best", "worst")
-  cols <- cols[cols %in% names(df)]
-  df_out <- df[, cols, drop = FALSE]
+  # Keep only the columns we need, in canonical order.
+  out_cols <- c("participant_id", "trial_id", "stimulus", "best", "worst")
+  out_cols <- out_cols[out_cols %in% names(df)]
+  df_out <- df[, out_cols, drop = FALSE]
 
+  # Stable sort: participant, then trial within participant.
   sort_cols <- intersect(c("participant_id", "trial_id"), names(df_out))
   df_out <- df_out[do.call(order, df_out[sort_cols]), , drop = FALSE]
 
   write_csv(df_out, file.path(processed_dir, "exp1.csv"))
 }
+
+# -----------------------------------------------------------------------------
+# Entry point
+# -----------------------------------------------------------------------------
+# When run via `Rscript`, resolve base_dir to the script's own directory so
+# relative paths (original_data/, processed_data/) work regardless of cwd.
 
 if (sys.nframe() == 0) {
   args <- commandArgs(trailingOnly = FALSE)


### PR DESCRIPTION
## Summary
Alternative, more thoroughly documented version of the R port proposed in #35. Same `scripts/examples_R/guenther2023ViSpa/` layout and byte-identical outputs — the only differences are in code readability:

- File-header blocks describing each script's inputs, outputs, and usage.
- Section dividers and inline comments on non-obvious steps:
  - Why `factor(..., levels = unique(...))` is required to match pandas' `factorize()` first-appearance ordering.
  - Why JSONL lines are built manually to match the `", "` / `": "` separators that Python's default `json.dumps` (used by `jsonlines`) produces.
- Helpers extracted: `ensure_processed_dir`, `write_codebook`, `build_participant_prompt`, `format_jsonl_line`.
- Instruction text and trial template pulled into named constants at the top of `generate_prompts.R`.

Intent: give future R contributors a reference that is both runnable and self-explanatory, without cross-referencing the Python source.

This PR supersedes #35 — maintainers can merge whichever presentation they prefer.

## Test plan
- [x] `Rscript preprocess_data.R` — `processed_data/exp1.csv` identical to the Python-generated file (`diff` → 0).
- [x] `Rscript generate_prompts.R` — `prompts.jsonl` identical to the Python-generated file (`diff` → 0, 601 lines).
- [x] Clean re-run from scratch reproduces both outputs.