### PR TITLE
Add luke2018_provo dataset and preprocess scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -33,3 +33,7 @@ berzak2025_onestop/original_data/ia_Paragraph.csv.zip filter=lfs diff=lfs merge=
 berzak2025_onestop/processed_data/*.csv filter=lfs diff=lfs merge=lfs -text
 berzak2025_onestop/prompts.jsonl.zip filter=lfs diff=lfs merge=lfs -text
 *.gz filter=lfs diff=lfs merge=lfs -text
+# LFS tracking for Luke & Christianson 2018 Provo Corpus contribution
+luke2018_provo/original_data/*.csv filter=lfs diff=lfs merge=lfs -text
+luke2018_provo/processed_data/*.csv filter=lfs diff=lfs merge=lfs -text
+luke2018_provo/prompts.jsonl.zip filter=lfs diff=lfs merge=lfs -text

--- a/CODEBOOK.csv
+++ b/CODEBOOK.csv
@@ -33,7 +33,7 @@ H_statistic,Entropy of the name distribution for the image (bits).
 Normalised_H_statistic,H-statistic normalised for sample-size differences.
 unknown_osullivan_et_al,Count of responses coded 'unknown' per O'Sullivan coding scheme.
 idiosyncratic_osullivan_et_al,Count of idiosyncratic (singleton) responses per O'Sullivan coding scheme.
-nonobject_osullivan_et_al,Count of non-object / unrelated responses per O’Sullivan coding scheme.
+nonobject_osullivan_et_al,Count of non-object / unrelated responses per Oâ€™Sullivan coding scheme.
 physically_dissimilar,Flag/score indicating physical dissimilarity of image variants.
 is_natural,Whether the object is a natural kind (true/false).
 is_modal,Whether the response equals the modal name for that image.
@@ -48,9 +48,9 @@ is_rt_outlier,Flag marking RT outliers removed from RT analyses.
 not_in_subtlex_uk,Flag if word not found in SUBTLEX-UK frequency resource.
 constituent_1,The first constituent of the compound word.
 constituent_2,The second constituent of the compound word.
-constituent_1_contribution,"Participant's rating of how much constituent_1 contributes to the compound's overall meaning (integer, 0–5; 0 = not at all, 5 = greatly)."
-constituent_2_contribution,"Participant's rating of how much constituent_2 contributes to the compound's overall meaning (integer, 0–5; 0 = not at all, 5 = greatly)."
-predictability,"Participant's rating of how easily the compound's meaning can be inferred from its two constituents (integer, 0–5; 0 = not at all, 5 = greatly)."
+constituent_1_contribution,"Participant's rating of how much constituent_1 contributes to the compound's overall meaning (integer, 0â€“5; 0 = not at all, 5 = greatly)."
+constituent_2_contribution,"Participant's rating of how much constituent_2 contributes to the compound's overall meaning (integer, 0â€“5; 0 = not at all, 5 = greatly)."
+predictability,"Participant's rating of how easily the compound's meaning can be inferred from its two constituents (integer, 0â€“5; 0 = not at all, 5 = greatly)."
 list_id,Experimental list number (0-indexed); indicates which list file the stimulus appeared in.
 start_time,Timestamp when the participant started the survey session (YYYY-MM-DD HH:MM:SS).
 completion_time,Timestamp when the participant completed the survey session (YYYY-MM-DD HH:MM:SS).
@@ -110,3 +110,11 @@ is_fixated,Binary indicator of whether a word received any fixation at all (eye-
 is_first_pass_skipped,Binary indicator of whether a word was skipped during first-pass reading. A first-pass skipped word may still be fixated later during a regression.
 is_regressed_into,Binary indicator of whether a regression entered a word (eye-tracking).
 is_regressed_out_of,Binary indicator of whether a regression left a word (eye-tracking).
+text_id,Identifier of the text or passage presented on a trial.
+sentence_number,Index of the sentence containing a word within its text or passage.
+word_in_sentence_number,Position of a word within its sentence.
+word_length,Number of characters in the presented word.
+word_class,Whether a word is a content word or a function word.
+cloze_predictability,Proportion of norming participants who produced this exact word form in a cloze task (0-1).
+pos_predictability,Proportion of cloze responses matching the word's part of speech (0-1).
+cloze_certainty,Certainty of the cloze response distribution for a word (0-1).

--- a/luke2018_provo/CODEBOOK.csv
+++ b/luke2018_provo/CODEBOOK.csv
@@ -1,0 +1,24 @@
+Recommended Column Name,Description
+participant_id,Unique identifier assigned to each participant (original labels Sub01-Sub84 remapped to integers 1-84).
+trial_order,Presentation order of the passage within the session (1-55). Passage order was randomised per participant.
+text_id,Identifier of the passage that was read (1-55). Constant across participants.
+word_position,Position of the word within its passage (1-based; from the DataViewer interest-area index).
+sentence_number,Index of the sentence containing this word within the passage. Empty for the first word of each passage.
+word_in_sentence_number,Position of the word within its sentence. Empty for the first word of each passage.
+stimulus,The word as displayed on screen for this interest area.
+word_length,Number of characters in the word. Empty for the first word of each passage.
+part_of_speech,Part of speech of the presented stimulus.
+word_class,Whether the word is a content or a function word.
+cloze_predictability,"Proportion of norming participants who produced this exact word form in the cloze task (0-1). Empty for the first word of each passage."
+pos_predictability,"Proportion of cloze responses matching this word's part of speech (0-1). Empty for the first word of each passage."
+cloze_certainty,"Certainty of the cloze response distribution for this word (0-1). Empty for the first word of each passage."
+rt,"Total reading time on the word in milliseconds (dwell time summed over all fixations). 0 means the word was never fixated."
+first_fixation_duration,Duration of the first fixation on the word in milliseconds. Empty if the word was never fixated.
+gaze_duration,"Sum of fixations on the word during the first run through it, in milliseconds. Empty if the word was never fixated."
+go_past_time,"Time from first entering the word until moving past it to the right, including regressions, in milliseconds. Empty if the word was never fixated."
+fixation_count,Number of fixations landing on the word.
+run_count,Number of separate runs of fixations on the word.
+is_fixated,Binary indicator of whether the word received any fixation (1) or none at all (0).
+is_first_pass_skipped,"Binary indicator of whether the word was skipped during first-pass reading (1) or not (0). A first-pass skipped word may still be fixated later during a regression."
+is_regressed_into,Binary indicator of whether a regression entered this word. Empty if the word was never fixated.
+is_regressed_out_of,Binary indicator of whether a regression left this word. Empty if the word was never fixated.

--- a/luke2018_provo/README.md
+++ b/luke2018_provo/README.md
@@ -1,0 +1,79 @@
+# Reference:
+Luke, S. G., & Christianson, K. (2018). The Provo Corpus: A large eye-tracking corpus with predictability norms. *Behavior Research Methods*, 50(2), 826–833. https://doi.org/10.3758/s13428-017-0908-4
+
+# Data source:
+https://osf.io/sjefs/ (released under CC BY 4.0)
+
+Two files from the OSF project are included in `original_data/`:
+- `Provo_Corpus-Eyetracking_Data.csv` — the trial-level eye-tracking data used here.
+- `Provo_Corpus-Predictability_Norms.csv` — the cloze-norming study the predictability values are derived from. Included for provenance and used by `preprocess_data.py` as a consistency check.
+
+# Description
+Eye movements recorded while 84 native English speakers each read all 55 short
+passages of the Provo Corpus. Passages are 2–5 sentences long (up to 62 words)
+and are drawn from news articles, popular science, magazines and fiction.
+Passage order was randomised per participant.
+
+- **exp1.csv**: 230,412 rows = 84 participants × 2,743 words. One row per word
+  (DataViewer interest area) per participant. Reading-time measures are total
+  dwell time, first fixation duration, gaze duration and go-past time, together
+  with fixation counts, first-pass skipping and regression indicators. Each word
+  also carries the cloze predictability values from the accompanying norming
+  study.
+
+Participants read silently for comprehension and pressed a button to advance to
+the next passage. There was no lexical decision, naming or comprehension-question
+component — reading time is the only behavioural measure.
+
+# Prompts
+In `prompts.jsonl`, each passage is one trial and each word is listed with its
+**total reading time (dwell time) in milliseconds** marked with `<< >>`. Words
+that never received a fixation are marked `<<not fixated>>`; these account for
+33.4% of words, which is typical for L1 reading. The `rt` metadata field lists
+the reading times of the fixated words only.
+
+Each participant's session is split into **two consecutive batches** of
+passages, in the order the participant actually read them, with the batch number
+recorded in the `batch` metadata field. A full 55-passage session comes to about
+39,000 tokens, which exceeds the 32K-token budget in the contribution guide even
+though it stays under the validator's 100,000-character proxy. Splitting keeps
+every trial: 84 participants × 2 batches = 168 lines, each roughly 19,000–21,000
+tokens. No trials are dropped.
+
+The instructions shown in the prompts are a faithful reconstruction of the
+reading task, not a verbatim transcript. The EyeLink Experiment Builder project
+distributed with the corpus contains an `Instruction_screen` node, but the text
+of that screen was not saved in the released files (only the 55 passage screens
+and the standard EyeLink camera-setup screen are recoverable), so the original
+wording is not publicly available.
+
+# Notes
+- **Source encoding.** Both original files are Windows-1252 encoded, not UTF-8;
+  `preprocess_data.py` reads them as `cp1252`.
+- **`stimulus` comes from `IA_LABEL`, not `Word`.** `IA_LABEL` is what was drawn
+  on screen. The `Word` column originates from the norming spreadsheet and
+  contains artefacts — most visibly the word "true" stored as the boolean
+  `TRUE` (text 3) — as well as sentence punctuation attached to tokens. The two
+  columns disagree on 1.7% of rows. Reconstructing each passage from the
+  processed `stimulus` values reproduces all 55 source passages.
+- **`is_fixated` is derived from `rt > 0`, not from `IA_SKIP`.** `IA_SKIP` marks
+  *first-pass* skipping, so 24,759 rows have `IA_SKIP == 1` despite having been
+  fixated later during a regression. Using `IA_SKIP` would mislabel those words
+  as unread.
+- **Structurally missing values.** `first_fixation_duration`, `gaze_duration`,
+  `go_past_time`, `is_regressed_into` and `is_regressed_out_of` are empty for
+  the 33.4% of words that were never fixated. These measures are undefined for
+  an unfixated word rather than missing data.
+- **Words without cloze norms.** 84 of each participant's 2,743 words have no
+  predictability values: the 55 passage-initial words (a cloze score requires
+  preceding context) plus 29 proper nouns and hyphenated compounds where the
+  norming study and the interest areas tokenise differently (e.g. "Rongorongo",
+  "Gaga's", "profession--writing."). The norming file itself covers 2,688 words.
+- **`word_position` comes from `IA_ID`,** which is complete and contiguous
+  within each passage. The source `Word_Number` column is empty for
+  passage-initial words.
+- **The predictability norms are not exported as a second experiment.** They are
+  aggregated over norming participants (response counts and proportions per
+  word, with no participant identifiers), so they are not trial-level data.
+- **No participant demographics.** Age, gender and language background are not
+  distributed with the corpus, so no demographic fields are included.

--- a/luke2018_provo/generate_prompts.py
+++ b/luke2018_provo/generate_prompts.py
@@ -1,0 +1,133 @@
+"""Generate participant-level LLM prompts for the Provo Corpus.
+
+Reads processed_data/exp1.csv and writes prompts.jsonl.zip, following the
+formatting of the continuous-outcome example in the repository README and of
+frank2013_reading.
+
+Each passage the participant read becomes one trial, presented word by word
+with the total reading time on that word marked in ``<< >>``. Words that never
+received a fixation are marked ``<<not fixated>>``.
+
+Sessions are split into two batches
+-----------------------------------
+Each participant read all 55 passages (2,743 words), which comes to roughly
+39,000 tokens in a single prompt -- over the 32K-token budget in the README,
+even though it stays under the validator's 100,000-character proxy. Each
+session is therefore split into two consecutive batches of passages, in the
+order the participant actually read them, and the batch number is recorded in
+the ``batch`` metadata field. This is the same approach used for other
+oversized sessions in this repository. No trials are dropped.
+"""
+
+import json
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+
+BASE_DIR = Path(__file__).parent.resolve()
+PROCESSED_FILE = BASE_DIR / "processed_data" / "exp1.csv"
+JSONL_PATH = BASE_DIR / "prompts.jsonl"
+ZIP_PATH = BASE_DIR / "prompts.jsonl.zip"
+
+EXPERIMENT_NAME = "luke2018_provo"
+
+# Number of consecutive batches each participant's session is split into.
+N_BATCHES = 2
+
+INSTRUCTION = (
+    "You will read short passages of English text presented one at a time on a "
+    "screen. Read each passage silently and at your own pace, for comprehension, "
+    "as you normally would. Your eye movements are recorded while you read. "
+    "Press the button when you have finished reading a passage to move on to the "
+    "next one. We will measure how long you look at each word.\n\n"
+)
+
+
+def format_trial(trial_number: int, words: pd.DataFrame) -> tuple[str, list[int]]:
+    """Render one passage as a numbered trial block."""
+    lines = [f"Trial {trial_number}:\n"]
+    reading_times: list[int] = []
+
+    for _, row in words.iterrows():
+        position = int(row["word_position"])
+        word = row["stimulus"]
+        reading_time = int(row["rt"])
+
+        if reading_time > 0:
+            lines.append(f"  Word {position}: '{word}'  <<{reading_time}>> ms\n")
+            reading_times.append(reading_time)
+        else:
+            lines.append(f"  Word {position}: '{word}'  <<not fixated>>\n")
+
+    lines.append("\n")
+    return "".join(lines), reading_times
+
+
+def build_prompts(df: pd.DataFrame) -> list[dict]:
+    prompts = []
+
+    for participant_id, participant_rows in df.groupby("participant_id", sort=True):
+        # Passages in the order this participant actually read them.
+        trial_orders = sorted(participant_rows["trial_order"].unique())
+        batches = _split_evenly(trial_orders, N_BATCHES)
+
+        for batch_number, batch_trials in enumerate(batches, start=1):
+            text = INSTRUCTION
+            reading_times: list[int] = []
+
+            for trial_number, trial_order in enumerate(batch_trials, start=1):
+                words = participant_rows[
+                    participant_rows["trial_order"] == trial_order
+                ].sort_values("word_position")
+                trial_text, trial_rts = format_trial(trial_number, words)
+                text += trial_text
+                reading_times.extend(trial_rts)
+
+            prompts.append(
+                {
+                    "text": text,
+                    "experiment": EXPERIMENT_NAME,
+                    "participant_id": int(participant_id),
+                    "batch": batch_number,
+                    "rt": reading_times,
+                }
+            )
+
+    return prompts
+
+
+def _split_evenly(items: list, n_parts: int) -> list[list]:
+    """Split *items* into *n_parts* consecutive, near-equal chunks."""
+    size, remainder = divmod(len(items), n_parts)
+    chunks = []
+    start = 0
+    for i in range(n_parts):
+        stop = start + size + (1 if i < remainder else 0)
+        chunks.append(items[start:stop])
+        start = stop
+    return chunks
+
+
+def main() -> None:
+    df = pd.read_csv(PROCESSED_FILE, low_memory=False)
+
+    prompts = build_prompts(df)
+
+    with open(JSONL_PATH, "w", encoding="utf-8") as f:
+        for entry in prompts:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+    with zipfile.ZipFile(ZIP_PATH, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.write(JSONL_PATH, "prompts.jsonl")
+    JSONL_PATH.unlink()
+
+    lengths = [len(entry["text"]) for entry in prompts]
+    print(f"Wrote {ZIP_PATH.name}")
+    print(f"  lines:        {len(prompts)} "
+          f"({df['participant_id'].nunique()} participants x {N_BATCHES} batches)")
+    print(f"  chars/line:   min {min(lengths):,} max {max(lengths):,}")
+
+
+if __name__ == "__main__":
+    main()

--- a/luke2018_provo/original_data/Provo_Corpus-Eyetracking_Data.csv
+++ b/luke2018_provo/original_data/Provo_Corpus-Eyetracking_Data.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38aedcb29bc9171009916eb2bcc2375729f104a2a1005c64a563da94b611b9e7
+size 69662713

--- a/luke2018_provo/original_data/Provo_Corpus-Predictability_Norms.csv
+++ b/luke2018_provo/original_data/Provo_Corpus-Predictability_Norms.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:965fb72eab55f51e08fc1b5622638b85b1085976ff513e2a7bee4adbbd4e6489
+size 14301138

--- a/luke2018_provo/preprocess_data.py
+++ b/luke2018_provo/preprocess_data.py
@@ -1,0 +1,173 @@
+"""Preprocess the Provo Corpus (Luke & Christianson, 2018) for PsychLing-101.
+
+Reads the two source files in original_data/ and writes a single tidy,
+trial-level CSV to processed_data/exp1.csv, with column names following
+CODEBOOK.csv.
+
+One row = one word (interest area) read by one participant.
+
+Notes on source-data quirks handled here
+----------------------------------------
+* Both source files are Windows-1252 encoded, not UTF-8.
+* ``IA_LABEL`` (what was actually drawn on screen) is used as the stimulus
+  rather than ``Word``. The ``Word`` column comes from the cloze-norming
+  spreadsheet and contains spreadsheet artefacts (e.g. the word "true" stored
+  as the boolean "TRUE") as well as sentence punctuation attached to the token.
+* ``Word_Number`` is missing for the first word of every passage, because the
+  cloze norms only cover words that have a preceding context. ``IA_ID`` is
+  complete and contiguous, so it is used for word position.
+* ``IA_SKIP`` marks first-pass skipping, so a word with IA_SKIP == 1 may still
+  have been fixated later during a regression. Whether a word was fixated at
+  all is therefore derived from ``IA_DWELL_TIME > 0``.
+"""
+
+from pathlib import Path
+
+import pandas as pd
+
+BASE_DIR = Path(__file__).parent.resolve()
+ORIGINAL_DIR = BASE_DIR / "original_data"
+PROCESSED_DIR = BASE_DIR / "processed_data"
+
+EYETRACKING_FILE = ORIGINAL_DIR / "Provo_Corpus-Eyetracking_Data.csv"
+NORMS_FILE = ORIGINAL_DIR / "Provo_Corpus-Predictability_Norms.csv"
+
+SOURCE_ENCODING = "cp1252"
+
+# Source column -> CODEBOOK column
+COLUMN_MAP = {
+    "Text_ID": "text_id",
+    "IA_ID": "word_position",
+    "Sentence_Number": "sentence_number",
+    "Word_In_Sentence_Number": "word_in_sentence_number",
+    "Word_Length": "word_length",
+    "Word_POS": "part_of_speech",
+    "Word_Content_Or_Function": "word_class",
+    "OrthographicMatch": "cloze_predictability",
+    "POSMatch": "pos_predictability",
+    "Certainty": "cloze_certainty",
+    "IA_DWELL_TIME": "rt",
+    "IA_FIRST_FIXATION_DURATION": "first_fixation_duration",
+    "IA_FIRST_RUN_DWELL_TIME": "gaze_duration",
+    "IA_REGRESSION_PATH_DURATION": "go_past_time",
+    "IA_FIXATION_COUNT": "fixation_count",
+    "IA_RUN_COUNT": "run_count",
+    "IA_SKIP": "is_first_pass_skipped",
+    "IA_REGRESSION_IN": "is_regressed_into",
+    "IA_REGRESSION_OUT": "is_regressed_out_of",
+}
+
+# Order of columns in the output file
+OUTPUT_COLUMNS = [
+    "participant_id",
+    "trial_order",
+    "text_id",
+    "word_position",
+    "sentence_number",
+    "word_in_sentence_number",
+    "stimulus",
+    "word_length",
+    "part_of_speech",
+    "word_class",
+    "cloze_predictability",
+    "pos_predictability",
+    "cloze_certainty",
+    "rt",
+    "first_fixation_duration",
+    "gaze_duration",
+    "go_past_time",
+    "fixation_count",
+    "run_count",
+    "is_fixated",
+    "is_first_pass_skipped",
+    "is_regressed_into",
+    "is_regressed_out_of",
+]
+
+INTEGER_COLUMNS = [
+    "participant_id",
+    "trial_order",
+    "text_id",
+    "word_position",
+    "sentence_number",
+    "word_in_sentence_number",
+    "word_length",
+    "rt",
+    "fixation_count",
+    "run_count",
+    "is_fixated",
+    "is_first_pass_skipped",
+    "is_regressed_into",
+    "is_regressed_out_of",
+]
+
+
+def check_norms_coverage(df: pd.DataFrame) -> None:
+    """Sanity-check the processed data against the cloze-norming source file.
+
+    The cloze predictability values in the eye-tracking file are derived from
+    the norming study distributed alongside it. The norms are aggregated over
+    norming participants (response counts per word), so they are not a
+    trial-level experiment in their own right and are not exported separately;
+    they are used here only to verify that the passages line up.
+    """
+    norms = pd.read_csv(
+        NORMS_FILE,
+        encoding=SOURCE_ENCODING,
+        usecols=["Text_ID", "Word_Number"],
+        low_memory=False,
+    )
+    expected_passages = set(norms["Text_ID"].unique())
+    actual_passages = set(df["text_id"].unique())
+    if expected_passages != actual_passages:
+        raise ValueError(
+            "Passage IDs in the eye-tracking data do not match the norms file: "
+            f"{sorted(expected_passages ^ actual_passages)}"
+        )
+    print(f"  norms check: {len(actual_passages)} passages match the norming file")
+
+
+def main() -> None:
+    PROCESSED_DIR.mkdir(exist_ok=True)
+
+    df = pd.read_csv(EYETRACKING_FILE, encoding=SOURCE_ENCODING, low_memory=False)
+
+    df = df.rename(columns=COLUMN_MAP)
+
+    # Participant IDs ("Sub01") -> sequential integers starting at 1.
+    participant_order = sorted(df["Participant_ID"].unique())
+    id_map = {p: i + 1 for i, p in enumerate(participant_order)}
+    df["participant_id"] = df["Participant_ID"].map(id_map)
+
+    # TRIAL_INDEX is the order in which this participant saw the passages.
+    # Passage order was randomised per participant, so this is not the same as
+    # text_id. It already runs 1..55.
+    df["trial_order"] = df["TRIAL_INDEX"].astype(int)
+
+    # What was actually displayed on screen, without DataViewer's trailing pad.
+    df["stimulus"] = df["IA_LABEL"].astype(str).str.strip()
+
+    # A word counts as fixated if it accrued any dwell time.
+    df["is_fixated"] = (df["rt"] > 0).astype(int)
+
+    check_norms_coverage(df)
+
+    df = df.sort_values(["participant_id", "trial_order", "word_position"])
+
+    out = df[OUTPUT_COLUMNS].copy()
+
+    for column in INTEGER_COLUMNS:
+        out[column] = out[column].astype("Int64")
+
+    output_path = PROCESSED_DIR / "exp1.csv"
+    out.to_csv(output_path, index=False, encoding="utf-8")
+
+    print(f"Wrote {output_path}")
+    print(f"  rows:         {len(out):,}")
+    print(f"  participants: {out['participant_id'].nunique()}")
+    print(f"  passages:     {out['text_id'].nunique()}")
+    print(f"  fixated:      {out['is_fixated'].mean():.1%} of words")
+
+
+if __name__ == "__main__":
+    main()

--- a/luke2018_provo/processed_data/exp1.csv
+++ b/luke2018_provo/processed_data/exp1.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f574c9d4871ca3e88139dedb33bb45631a70a5b4a4632ebdb5f28fda17a8270
+size 22167164

--- a/luke2018_provo/prompts.jsonl.zip
+++ b/luke2018_provo/prompts.jsonl.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5340f32fec7bddc1781a2bbf90c096c80817e5904e88ce5eea7d69e427bbb791
+size 1965667


### PR DESCRIPTION
Adds the Provo Corpus (Luke & Christianson, 2018), eye movements from 84 native English speakers reading all 55 passages. The folder is `luke2018_provo`.

`processed_data/exp1.csv` has 230,412 rows, one per word per participant. It carries total reading time, first fixation duration, gaze duration, go past time, fixation and run counts, first pass skipping, regressions, and the cloze predictability values from the norming study that ships with the corpus. Data comes from https://osf.io/sjefs/ under CC BY 4.0.

Each session is split into two lines with a `batch` metadata field, because a full 55 passage session runs to roughly 39,000 tokens, over the 32K budget in the guide, even though it stays under the character check in the validator. Splitting keeps every trial, and 84 participants gives 168 lines at about 19,000 to 21,000 tokens each.

The displayed word is taken from `IA_LABEL` rather than the `Word` column, since `Word` comes from the norming spreadsheet and is mangled in places, most visibly "true" stored as the boolean TRUE. Rebuilding each passage from the processed data reproduces all 55 source passages exactly.

Whether a word was fixated is derived from dwell time rather than `IA_SKIP`, which flags first pass skipping only, so 24,759 rows are marked skipped despite having been fixated later on a regression.

The instructions in the prompts are a reconstruction of the reading task. The Experiment Builder project that ships with the corpus has an instruction screen node, but the text of that screen was not saved in the released files, so the original wording is not available anywhere.

The predictability norms are not included as a second experiment, since they are aggregated over norming participants with no participant ids and so are not trial level data.

The validator passes with no errors. The remaining warnings are missing values in first fixation duration, gaze duration, go past time and the two regression columns, which are empty for the 33.4% of words that were never fixated, where those measures are undefined rather than missing.

New eye movement variables are added to the root `CODEBOOK.csv`, with an LFS entry scoped to this folder.
